### PR TITLE
Transfer view now renders account data

### DIFF
--- a/Course_Project/grizz_bank/static/grizz_bank/main.css
+++ b/Course_Project/grizz_bank/static/grizz_bank/main.css
@@ -41,6 +41,16 @@ div.vertical-horizontal-center {
     transform: translate(-50%, -50%);
 }
 
+div.horizontal-center-vertical-30 {
+    min-width: 50%;
+    margin: 0;
+    position: absolute;
+    top: 30%;
+    left: 50%;
+    j-ms-transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
+}
+
 section.content div.container {
     height: 75%;
     vertical-align: middle;
@@ -50,7 +60,8 @@ section.content div.container {
 }
 
 
-div.vertical-horizontal-center div.card, div.vertical-horizontal-center div.card-body {
+div.vertical-horizontal-center div.card, div.vertical-horizontal-center div.card-body,
+div.horizontal-center-vertical-30 div.card, div.horizontal-center-vertical-30 div.card-body {
     padding-right: 0;
     padding-left: 0;
     padding-top: 0;
@@ -70,7 +81,7 @@ div.row div.text-center {
     text-align: center;
 }
 
-div.vertical-horizontal-center div.card {
+div.vertical-horizontal-center div.card, div.horizontal-center-vertical-30 div.card {
     margin: 0.75em 0.75em 0.75em 0.75em;
 }
 

--- a/Course_Project/grizz_bank/templates/grizz_bank/transfer.html
+++ b/Course_Project/grizz_bank/templates/grizz_bank/transfer.html
@@ -16,7 +16,7 @@
     <div class="main">
     <section class="header">
         <nav class="navbar navbar-expand-md navbar-dark">
-            <a href="/grizz_bank/" class="navbar-brand">Grizz Bank</a>
+            <a href="/grizz_bank/" class="navbar-brand">GrizzBank</a>
             <div class="collapse navbar-collapse">
                 <ul class="navbar-nav">
                     <li class="nav-item"><a class="nav-link" href="../withdraw_deposit">Deposit or Withdraw</a></li>
@@ -29,7 +29,7 @@
     </section>
 
     <section class="content">
-    <div class="vertical-horizontal-center">
+    <div class="horizontal-center-vertical-30">
         <form method="post" >
              <div class="row">
                 <div class="col card">
@@ -38,17 +38,14 @@
                             <h2 class="text-center card-title">Transfer From</h2>
                         </div>
                         <div class="btn-group-toggle" data-toggle="buttons">
-                             <!-- TODO: once DB refactored, transfer view builds these dummy acct lists via
-                                    template lang. Also, JS to restrict btns to 1 checked per card -->
+                             <!-- TODO: JS to restrict btns to 1 checked per card -->
                             <ul class="lst-rad-btns">
-                                <li>
-                                    <label for="sav_acct1_from">Savings Account id#####: <span class="acct-bal">$3000.00: </span></label>
-                                    <input class="radio" type="radio" id="sav_acct1_from" name="sav_acct">
-                                </li>
-                                <li>
-                                    <label for="chk_acct1_from">Checking Account id#####: <span class="acct-bal">$1000.00: </span></label>
-                                    <input class="radio" type="radio" id="chk_acct1_from" name="chk_acct1">
-                                </li>
+                                {%for acct in account_data %}
+                                    <li>
+                                        <label for="acct{{acct.id}}_from">{{acct.type}} Account {{acct.id}}: <span class="acct-bal">${{acct.bal}}: </span></label>
+                                        <input class="radio" type="radio" id="acct{{acct.id}}_from" name="acct{{acct.id}}">
+                                    </li>
+                                {% endfor %}
                             </ul>
                         </div>
                     </div>
@@ -59,14 +56,13 @@
                             <h2 class="text-center card-title">Transfer To</h2>
                         </div>
                          <ul class="lst-rad-btns">
-                        <!-- TODO: once DB refactored, transfer view builds these dummy acct lists via template lang -->
-                        <li><label for="sav_acct1_to">Savings Account id##### </label>
-                            <input class="radio" type="radio" id="sav_acct1_to" name="sav_acct1_to">
-                        </li>
-                         <li>
-                            <label for="chk_acct1_to">Checking Account id##### </label>
-                            <input class="radio" type="radio" id="chk_acct1_to" name="chk_acct1_to">
-                         </li>
+                        <!-- TODO: JS to ensure only one button in this list selected -->
+                             {%for acct in account_data %}
+                                <li>
+                                    <label for="acct{{acct.id}}_to">{{acct.type}} Account {{acct.id}}: <span class="acct-bal">${{acct.bal}}: </span></label>
+                                    <input class="radio" type="radio" id="acct{{acct.id}}_to" name="acct{{acct.id}}">
+                                </li>
+                             {% endfor %}
                          </ul>
                     </div>
                 </div>
@@ -84,7 +80,7 @@
 
     <footer class="footer">
         <nav class="navbar navbar-expand-sm navbar-dark">
-            <a href="#" class="navbar-brand">About Grizz Bank</a>
+            <a href="#" class="navbar-brand">About GrizzBank</a>
             <div class="collapse navbar-collapse">
                 <ul class="navbar-nav">
                     <li class="nav-item"><a class="nav-link" href="#">About us</a></li>

--- a/Course_Project/grizz_bank/views.py
+++ b/Course_Project/grizz_bank/views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import render
+from .models import *  # import all of the model classes
 from django.http import HttpResponse
 
 # Create your views here.
@@ -22,7 +23,6 @@ def reset_password(request):
 def login(request):
     pass
     context ={}
-
     return render(request, "grizz_bank/login.html", context)
 
 
@@ -33,7 +33,33 @@ def transfer(request):
     :param request: Django HTTPS GET Request
     :return: HTTPS Response with HTML rendered per transfer.html template
     """
-    context ={}
+    def create_account_data_list(accounts):
+        """
+        Helper function which transforms data from a Django Account row object into a list of python dictionaries
+        containing account data (type, balance, id)
+        rendering in the template.
+        :param accounts: list of Account row objects
+        :return: python dictionary
+        """
+        # dictionary mapping account type key to an actual account type name
+        types = {"S": "Savings", "C": "Checking"}
+        # List comprehension returning a list of dicitonaries containing account type, balance, and ID
+        acct_data = [{"type": types[acct.acct_type], "bal": acct.acct_bal, "id": acct.acct_id} for acct in accounts]
+        return acct_data
+
+    context = {}
+    uname = request.GET["uname"]
+    try:
+        client_id = Client.objects.get(username=uname).client_id
+        client_accounts = Account.objects.filter(client_id=client_id)
+        # List comprehension to build a list of python dictionaries containing account data into the context
+        context["account_data"] = create_account_data_list(client_accounts)
+        context["error"] = False
+    except Exception as e:
+        # If an error happens log to console, set context error flag true, and make account data an empty list
+        print(e)
+        context["error"] = True
+        context["account_data"] = list()
 
     return render(request, "grizz_bank/transfer.html", context)
 


### PR DESCRIPTION
transfer template and view now work to dynamically render the client accounts into the Transfer to/from cards. Minor main.css edits,
but these were simply adding selectors to existing rules, so shouldn't break anything. 

Test changes to transfer view by:
1. Creating a client account
2. Create account types in the interest rate table
3. Creating accounts with foreign key as client account's primary id
4. Test with this url
127.0.0.1:8000/grizz_bank/transfer/?uname=yourUsernameHere